### PR TITLE
Make ceaser-transition compatible with compass 0.12

### DIFF
--- a/stylesheets/ceaser-easing/_ceaser.sass
+++ b/stylesheets/ceaser-easing/_ceaser.sass
@@ -9,5 +9,5 @@
 
 @mixin ceaser-transition($type: "ease", $properties: all, $duration: 500ms, $delay: 0)
   $easingValue : returnEaseType($type)
-  @include transition($properties, $duration, cubic-bezier(unquote($easingValue)), $delay)
+  @include transition($properties $duration cubic-bezier(unquote($easingValue)) $delay)
 


### PR DESCRIPTION
This is one way to do that, the other is to replace transition() by single-transition()
