### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Compass Ceaser CSS Easing Transitions
 ======================================
 
-A compass extension based on [ceasar css easing animation tool](http://matthewlein.com/ceaser/) by [@matthewlein](http://twitter.com/matthewlein)
+A compass extension based on [caesar css easing animation tool](http://matthewlein.com/ceaser/) by [@matthewlein](http://twitter.com/matthewlein)
 This extension provides transitions based on the classic Penner equations from Flash and jQuery.
 
 


### PR DESCRIPTION
jhardy, I've corrected a typographical error in the documentation of the [compass-ceaser-easing](https://github.com/jhardy/compass-ceaser-easing) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
